### PR TITLE
Update README

### DIFF
--- a/README
+++ b/README
@@ -1,5 +1,4 @@
 
-
   Text::BibTeX
 ---------------------------------------------------------------------------
 
@@ -33,7 +32,7 @@
   btparse documentation is a further 30 pages).  You can find it at
   the btOOL home page:
 
-    http://starship.python.net/~gward/btOOL/
+    http://www.gerg.ca/software/btOOL/
 
 
   INSTALLATION


### PR DESCRIPTION
Link to btOOL homepage (with TR) 404ed, change to newish location
