### PR TITLE
fix build on non-x86 64-bit arches

### DIFF
--- a/Build.PL
+++ b/Build.PL
@@ -79,7 +79,7 @@ if ($^O =~ /mswin32/i) {
         unlink catfile($libdir, $target);
     }
 } else {
-    if ($Config{archname} =~ /^x86_64/) {
+    if ($Config{archname} =~ /^x86_64|^ppc64|^s390x|^aarch64/) {
         $libdir =~ s/\bbin\b/lib64/;
         if (!-d $libdir) {
             my $test = $libdir;


### PR DESCRIPTION
Patch originally by Dan Horák sharkcz@fedoraproject.org.

This fixes it for us on Fedora... but I don't know if these archnames are distro-specific?  Anyway, something needs to be done and this is something ;-)
