### PR TITLE
Allow state of btparse parser to be reset, for parsing multiple files

### DIFF
--- a/Changes
+++ b/Changes
@@ -2,6 +2,12 @@ Revision history for Perl module Text::BibTeX
 
  * Fixed some issues with uninitialized arrays and s390
  * Fixed test with fileno (thanks to Karl Wette).
+ * Allow state of btparse parser to be reset, for parsing multiple files (Karl Wette):
+   - bt_parse_entry(): reset parser state if infile == NULL
+   - BibTeX.xs: add _reset_parse(), _reset_parse_s() methods to Text::BibTeX::Entry
+   - Text::BibTeX::Entry: allow new() or parse() with undefined filehandle; calls _reset_parse()
+   - Text::BibTeX::Entry: allow new() or parse_s() with undefined text; calls _reset_parse_s()
+   - Text::BibTeX::File: close() calls Text::BibTeX::Entry->new($filename, undef) to reset parser
 
 0.77 2016-09-20
  * Fixes for testing and installing on Darwin (install_name issues).

--- a/MANIFEST
+++ b/MANIFEST
@@ -152,4 +152,5 @@ README.OLD
 META.json
 MANIFEST.SKIP
 t/corpora.bib
+t/errors.bib
 t/from_file.t

--- a/btparse/src/.gitignore
+++ b/btparse/src/.gitignore
@@ -1,1 +1,2 @@
 *.o
+libbtparse.so

--- a/lib/Text/BibTeX/File.pm
+++ b/lib/Text/BibTeX/File.pm
@@ -20,6 +20,7 @@ package Text::BibTeX::File;
 use strict;
 use Carp;
 use IO::File;
+use Text::BibTeX::Entry;
 
 use vars qw'$VERSION';
 $VERSION = 0.77;
@@ -174,7 +175,10 @@ sub open {
 sub close
 {
    my $self = shift;
-   $self->{handle}->close if $self->{handle};   
+   if ( $self->{handle} ) {
+      Text::BibTeX::Entry->new ($self->{filename}, undef);   # resets parser
+      $self->{handle}->close;
+   }
 }
 
 sub eof

--- a/t/errors.bib
+++ b/t/errors.bib
@@ -1,0 +1,7 @@
+@Article{error1,
+  author {error},
+  title = {title},
+}
+
+article{error2,
+}

--- a/t/from_file.t
+++ b/t/from_file.t
@@ -1,10 +1,12 @@
 use strict;
 use warnings;
 
-use Test::More tests => 5;
+use Test::More tests => 11;
 use utf8;
 
 use Text::BibTeX;
+
+##### parse t/corpora.bib #####
 
 my $bibtex = Text::BibTeX::File->new("t/corpora.bib", { binmode => 'utf-8'});
 is ref($bibtex), "Text::BibTeX::File";
@@ -33,3 +35,39 @@ is $entries[0]->get("author"), "Gustavo Laboreiro and Eugénio Oliveira";
 my @editors = $entries[0]->names("editor");
 
 is $editors[0]->part("last"), "Simões";
+
+##### parse t/corpora.bib again to check whether bt_parse_entry() state has been reset #####
+
+$bibtex = Text::BibTeX::File->new("t/corpora.bib", { binmode => 'utf-8'});
+is ref($bibtex), "Text::BibTeX::File";
+
+@entries = ();
+while (my $entry = Text::BibTeX::Entry->new($bibtex)) {
+	push @entries, $entry;
+}
+
+is scalar(@entries), 25;
+
+##### parse t/error.bib to check whether bt_parse_entry() state can reset after error #####
+
+$bibtex = Text::BibTeX::File->new("t/errors.bib", { binmode => 'utf-8'});
+is ref($bibtex), "Text::BibTeX::File";
+
+@entries = ();
+while (my $entry = Text::BibTeX::Entry->new($bibtex)) {
+	push @entries, $entry;
+}
+
+is scalar(@entries), 1;
+
+##### parse t/corpora.bib again to check whether bt_parse_entry() state has been reset #####
+
+$bibtex = Text::BibTeX::File->new("t/corpora.bib", { binmode => 'utf-8'});
+is ref($bibtex), "Text::BibTeX::File";
+
+@entries = ();
+while (my $entry = Text::BibTeX::Entry->new($bibtex)) {
+	push @entries, $entry;
+}
+
+is scalar(@entries), 25;

--- a/t/parse_s.t
+++ b/t/parse_s.t
@@ -3,7 +3,7 @@ use strict;
 use warnings;
 use utf8;
 use IO::Handle;
-use Test::More tests => 46;
+use Test::More tests => 50;
 
 use vars qw($DEBUG);
 
@@ -75,16 +75,17 @@ test_entry ($entry, 'foo', 'mykey',
             ['hello there', 'fancy that!1991', '']);
 
 # Make sure parsing an empty string, or string with no entry in it,
-# just returns false... nope, doesn't work right now.  Need to
-# look into how btparse responds to bt_parse_s() on an empty string
-# before I know how Text::BibTeX should do it!
+# just returns false
 
-# $entry = Text::BibTeX::Entry->new();
-# $result = $entry->parse_s ('');
-# ok(! warnings && ! $result);
-
-# $result = $entry->parse_s ('top-level junk that is not caught');
-# ok(! warnings && ! $result);
+$entry = Text::BibTeX::Entry->new();
+$result = $entry->parse_s ('');
+ok(! $result);
+$result = $entry->parse_s (undef);
+ok(! $result);
+$result = $entry->parse_s ('top-level junk that is not caught');
+ok(! $result);
+$result = $entry->parse_s (undef);
+ok(! $result);
 
 
 # Test the "proper noun at both ends" bug (the bt_get_text() call in

--- a/xscode/BibTeX.xs
+++ b/xscode/BibTeX.xs
@@ -169,6 +169,9 @@ MODULE = Text::BibTeX   	PACKAGE = Text::BibTeX::Entry
 # ast_to_hash() to do the appropriate "convert to Perl form" work:
 #    _parse
 #    _parse_s
+# These XSUBs reset the internal parser states:
+#    _reset_parse
+#    _reset_parse_s
 
 int
 _parse (entry_ref, filename, file, preserve=FALSE)
@@ -198,6 +201,20 @@ _parse (entry_ref, filename, file, preserve=FALSE)
 
 
 int
+_reset_parse ()
+
+    PREINIT:
+        btshort  options = 0;
+        boolean status;
+
+    CODE:
+
+        bt_parse_entry (NULL, NULL, options, &status);
+
+        XSRETURN_NO;              /* cleanup -- return false to perl */
+
+
+int
 _parse_s (entry_ref, text, preserve=FALSE)
     SV *    entry_ref;
     char *  text;
@@ -218,6 +235,20 @@ _parse_s (entry_ref, text, preserve=FALSE)
 
         ast_to_hash (entry_ref, top, status, preserve);
         XSRETURN_YES;              /* OK -- return true to perl */
+
+
+int
+_reset_parse_s ()
+
+    PREINIT:
+        btshort  options = 0;
+        boolean status;
+
+    CODE:
+
+        bt_parse_entry_s (NULL, NULL, 1, options, &status);
+
+        XSRETURN_NO;              /* cleanup -- return false to perl */
 
 
 MODULE = Text::BibTeX           PACKAGE = Text::BibTeX::Name


### PR DESCRIPTION
It is currently very difficult to get Text::BibTeX to parse multiple files, especially when errors are encountered in the first file. This is because btparse has an internal parser state which must be reset between files, but this is currently very hard to accomplish (i.e. bt_parse_entry() must be passed a FILE for which feof() is true, which seems to be difficult to construct from Perl due to buffering, etc.)

This pull request allows the state of `btparse` to be reset explicitly from Perl, so that parsing multiple files becomes possible. As documented in `Changes`, it does the following:
   - bt_parse_entry(): reset parser state if infile == NULL
   - BibTeX.xs: add _reset_parse(), _reset_parse_s() methods to Text::BibTeX::Entry
   - Text::BibTeX::Entry: allow new() or parse() with undefined filehandle; calls _reset_parse()
   - Text::BibTeX::Entry: allow new() or parse_s() with undefined text; calls _reset_parse_s()
   - Text::BibTeX::File: close() calls Text::BibTeX::Entry->new($filename, undef) to reset parser

In short, the parser should now automatically reset for anyone using Text::BibTeX::File to parse BibTeX entries; for anyone using Text::BibTeX::Entry->new($filename, $filehandle) or Text::BibTeX::Entry->new($text) to parse entries, passing $filehandle == undef or $text == undef will also reset the parser.