### PR TITLE
Use "/usr/bin/perl" in examples and scripts

### DIFF
--- a/examples/append_entries
+++ b/examples/append_entries
@@ -1,4 +1,4 @@
-#!/usr/local/bin/perl5 -w
+#!/usr/bin/perl -w
 
 #
 # append_entries

--- a/scripts/btcheck
+++ b/scripts/btcheck
@@ -1,4 +1,4 @@
-#!/usr/local/bin/perl5 -w
+#!/usr/bin/perl -w
 
 #
 # btcheck

--- a/scripts/btformat
+++ b/scripts/btformat
@@ -1,4 +1,4 @@
-#!/usr/local/bin/perl -w
+#!/usr/bin/perl -w
 
 use strict;
 use Text::BibTeX;

--- a/scripts/btsort
+++ b/scripts/btsort
@@ -1,4 +1,4 @@
-#!/usr/local/bin/perl -w
+#!/usr/bin/perl -w
 
 #
 # btsort


### PR DESCRIPTION
Some examples and scripts used a "/usr/local/bin/perl" shebang, some
specifying perl5 as well.  Replace with "/usr/bin/perl".