### PR TITLE
Fix spelling typos in documention

### DIFF
--- a/btparse/doc/bt_language.pod
+++ b/btparse/doc/bt_language.pod
@@ -94,7 +94,7 @@ regular expressions on the right:
    JUNK                  ~[\@\n\ \r\t]+
 
 (Note that this is PCCTS regular expression syntax, which should be
-fairly familar to users of other regex engines.  One oddity is that a
+fairly familiar to users of other regex engines.  One oddity is that a
 character class is negated as C<~[...]> rather than C<[^...]>.)
 
 On seeing C<at> at top-level, we enter in-entry mode.  Whitespace, junk,

--- a/lib/Text/BibTeX.pm
+++ b/lib/Text/BibTeX.pm
@@ -667,7 +667,7 @@ the input string is returned.
 
 OPTIONS is currently unused.
 
-=item change_case (TRANFORM, STRING [, OPTIONS])
+=item change_case (TRANSFORM, STRING [, OPTIONS])
 
 Transforms the case of STRING according to TRANSFORM (a single
 character, one of C<'u'>, C<'l'>, or C<'t'>).  See L<bt_misc> for

--- a/lib/Text/BibTeX/BibSort.pm
+++ b/lib/Text/BibTeX/BibSort.pm
@@ -70,7 +70,7 @@ to produce the sort key: non-English letters are mercilessly anglicized,
 non-alphabetic characters are stripped, and everything is forced to
 lowercase.  (The first two steps are done by the C<purify_string> routine;
 see L<Text::BibTeX/"Generic string-processing functions"> for a brief
-description, and the descripton of the C function C<bt_purify_string()> in
+description, and the description of the C function C<bt_purify_string()> in
 L<bt_misc> for all the gory details.)
 
 =cut

--- a/lib/Text/BibTeX/Entry.pm
+++ b/lib/Text/BibTeX/Entry.pm
@@ -534,7 +534,7 @@ L<Text::BibTeX::Value>.
 
 =item value ()
 
-Retuns the single string associated with C<@comment> and C<@preamble>
+Returns the single string associated with C<@comment> and C<@preamble>
 entries.  For instance, the entry
 
    @preamble{" This is   a preamble" # 

--- a/lib/Text/BibTeX/Structure.pm
+++ b/lib/Text/BibTeX/Structure.pm
@@ -80,7 +80,7 @@ basis of the B<btOOL> "structure module" system.  This system is how
 database structures are defined and imposed on BibTeX files, and
 provides an elegant synthesis of object-oriented techniques with
 BibTeX-style database structures.  Nothing described here is
-particularly deep or subtle; anyone familar with object-oriented
+particularly deep or subtle; anyone familiar with object-oriented
 programming should be able to follow it.  However, a fair bit of jargon
 in invented and tossed around, so pay attention.
 


### PR DESCRIPTION
During the packaging of this module in Debian we are currently applying these changes to fix some spelling typos in the documentation.

Original patch created by: Julián Moreno Patiño, Lucas Kanashiro, and gregor herrmann