### PR TITLE
Fix crashes in name formatting

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,5 +1,8 @@
 Revision history for Perl module Text::BibTeX
 
+ * Fix some crashes and malfunctinos in bt_format_name and bt_split_name (Tobias Schlemmer)
+ * Issue warnings for unmatched braces (Tobias Schlemmer) 
+
 0.85 2017-08-31
  * FreeBSD includes a definition of strlcat, so no need to redefine it.
 

--- a/btparse/src/format_name.c
+++ b/btparse/src/format_name.c
@@ -755,6 +755,7 @@ format_name (bt_name_format * format,
 
       for (j = 0; j < num_tokens[part]; j++)
       {
+	 if (!tokens[part][j]) continue; // ignore empty tokens
          offset += append_text (fname, offset, 
                                 format->pre_token[part], 0, -1);
 

--- a/btparse/src/names.c
+++ b/btparse/src/names.c
@@ -324,9 +324,14 @@ find_commas (name_loc * loc, char *name, int max_commas)
             }
 	    c = ' ';
          }
-      }
-      /* collapse white space */
-      if (isspace(c)) {
+	 /* preceeding whitespace is already collapsed.
+	    let's replace it with the comma */
+	 if (last_whitespace)
+		 --j;
+	 else /* remove following whitespace */
+		 last_whitespace = 1;
+      } else if (isspace(c)) {
+	      /* collapse white space */
 	      if (last_whitespace) continue;
 	      else last_whitespace = 1;
       } else {

--- a/btparse/src/names.c
+++ b/btparse/src/names.c
@@ -415,6 +415,7 @@ find_tokens (char *  name,
    /* tokens->string = name ? strdup (name) : NULL; */
    tokens->string = name;
    num_tok = 0;
+   tokens->num_items = 0;
    tokens->items = NULL;
 
    if (len == 0)                        /* empty string? */
@@ -818,6 +819,8 @@ bt_split_name (char *  name,
          split_name->parts[i] = NULL;
          split_name->part_len[i] = 0;
       }
+      split_name->tokens = NULL;
+      if (name) free(name);
       return split_name;
    }
 
@@ -868,6 +871,7 @@ bt_split_name (char *  name,
          split_name->parts[i] = NULL;
          split_name->part_len[i] = 0;
       }
+      split_name->tokens = NULL;
    }
    else
    {
@@ -908,6 +912,7 @@ bt_split_name (char *  name,
 void
 bt_free_name (bt_name * name)
 {
+	if (name && name->tokens && name->parts[BTN_LAST])
    DBG_ACTION (2, printf ("bt_free_name(): freeing name %p "
                           "(%d tokens, string=%p (%s), last[0]=%s)\n",
                           name, 

--- a/btparse/tests/namebug.c
+++ b/btparse/tests/namebug.c
@@ -1,8 +1,201 @@
 #include <stdio.h>
+#include <stdlib.h>
 #include <string.h>
+#include <ctype.h>
+#include <assert.h>
 #include "btparse.h"
 
+#if DEBUG
 void dump_name(bt_name*);
+#else
+#define dump_name(x) do {} while(0)
+#endif
+
+char * normalize_name(char * name) {
+	size_t size = strlen(name);
+	char * result = malloc(size + 1);
+	char * optr=result, *iptr=name;
+	int braces = 0;
+	char inspace = 0;
+	while (*iptr && isspace(*iptr)) ++iptr;
+	while (*iptr) {
+		printf("%c",*iptr);
+		switch (*iptr) {
+		case '{': {
+			if (braces < 0) {
+				++iptr;
+				break;
+			}
+			if (!braces) {
+				*optr++ = *iptr;
+			}
+			++braces;
+			++iptr;
+			inspace = 0;
+			break;
+		}
+		case '}': {
+			if (braces < 0) {
+				++iptr;
+				break;
+			}
+			--braces;
+			if (!braces) {
+				*optr++ = *iptr;
+				braces = -1;
+			}
+			++iptr;
+			inspace=0;
+			break;
+		}
+		case '\f':
+		case '\r':
+		case '\v':
+		case '\n':
+		case '\t':
+		case ' ': {
+			if (!inspace) {
+				*optr++ = *iptr;
+				inspace = 0;
+			}
+			iptr++;
+			break;
+		}
+		default:
+			inspace = 0;
+			*optr++ = *iptr++;
+		}
+	}
+	if (optr != result) {
+		--optr;
+		while (optr != result && isspace(*optr)) --optr;
+		++optr;
+	}
+	*optr = 0;
+	result = realloc(result, (optr-result)+1);
+	printf("\n");
+	return result;
+}
+
+
+struct nametype {
+	char * given; /*
+                         name_split->parts[BTN_GIVEN],
+                         name_split->part_len[BTN_GIVEN]);
+		     */
+	char * prefix; /*
+                         name_split->parts[BTN_PREFIX],
+                         name_split->part_len[BTN_PREFIX]);
+		   */
+	char * family; /*
+                         name_split->parts[BTN_FAMILY],
+                         name_split->part_len[BTN_FAMILY]);
+		     */
+	char * suffix; /*
+                         name_split->parts[BTN_SUFFIX],
+                         name_split->part_len[BTN_SUFFIX]);
+		    */
+	char * given_i;
+	char * prefix_i;
+	char * family_i;
+	char * suffix_i;
+};
+
+char * inits (char * c) { return c; }
+struct nametype parsename(char * namestr,
+			    char * fieldname) {
+	char * myname;
+	bt_name * name, * nd_name;
+	bt_name_format * l_f = bt_create_name_format("l",  0),
+		*f_f = bt_create_name_format("f", 0),
+		*p_f = bt_create_name_format("v", 0),
+		*s_f = bt_create_name_format("j", 0),
+		*li_f = bt_create_name_format("l",  0),
+		*fi_f = bt_create_name_format("f", 0),
+		*pi_f = bt_create_name_format("v", 0),
+		*si_f = bt_create_name_format("j", 0);
+	struct nametype retval;
+
+
+	myname = normalize_name(namestr);
+	name = bt_split_name(namestr,__FILE__,__LINE__,0);
+	dump_name (name);
+
+	bt_set_format_options(l_f,BTN_LAST,  0, BTJ_MAYTIE, BTJ_NOTHING);
+	bt_set_format_options(f_f,BTN_FIRST, 0, BTJ_MAYTIE, BTJ_NOTHING);
+	bt_set_format_options(p_f,BTN_VON,   0, BTJ_MAYTIE, BTJ_NOTHING);
+	bt_set_format_options(s_f,BTN_JR,    0, BTJ_MAYTIE, BTJ_NOTHING);
+
+	retval.family = bt_format_name(name,l_f);
+	retval.given  = bt_format_name(name,f_f);
+	retval.prefix = bt_format_name(name,p_f);
+	retval.suffix = bt_format_name(name,s_f);
+
+	nd_name = name;
+
+	bt_set_format_text(li_f,BTN_LAST,  NULL, NULL, NULL, "");
+	bt_set_format_text(fi_f,BTN_FIRST, NULL, NULL, NULL, "");
+	bt_set_format_text(pi_f,BTN_VON,   NULL, NULL, NULL, "");
+	bt_set_format_text(si_f,BTN_JR,    NULL, NULL, NULL, "");
+	bt_set_format_options(li_f,BTN_LAST,  1, BTJ_FORCETIE, BTJ_NOTHING);
+	bt_set_format_options(fi_f,BTN_FIRST, 1, BTJ_FORCETIE, BTJ_NOTHING);
+	bt_set_format_options(pi_f,BTN_VON,   1, BTJ_FORCETIE, BTJ_NOTHING);
+	bt_set_format_options(si_f,BTN_JR,    1, BTJ_FORCETIE, BTJ_NOTHING);
+
+	retval.family_i = inits(bt_format_name(nd_name,li_f));
+	retval.given_i  = inits(bt_format_name(nd_name,fi_f));
+	retval.prefix_i = inits(bt_format_name(nd_name,pi_f));
+	retval.suffix_i = inits(bt_format_name(nd_name,si_f));
+
+	free(myname);
+	bt_free_name(name);
+	bt_free_name_format(l_f);
+	bt_free_name_format(f_f);
+	bt_free_name_format(p_f);
+	bt_free_name_format(s_f);
+	bt_free_name_format(li_f);
+	bt_free_name_format(fi_f);
+	bt_free_name_format(pi_f);
+	bt_free_name_format(si_f);
+
+	return retval;
+}
+char * parse_strings[] = {
+	  "Ahrens, Dieter and Rottl{\"a}nder, {C.\bibtexspatium A.}",
+	  "Ahrens, Dieter and Rottländer, {C.\bibtexspatium A.}",
+	  "Ahrens, Dieter and Rottl{\"a}nder, {C.A."
+};
+#define parse_string_count 3
+
+void print_names(struct nametype names) {
+	printf("{ %s; %s; %s; %s  / %s; %s; %s; %s}\n",
+	       names.given,
+	       names.prefix,
+	       names.family,
+	       names.suffix,
+	       names.given_i,
+	       names.prefix_i,
+	       names.family_i,
+	       names.suffix_i);
+}
+void free_names(struct nametype * names) {
+	free (names->given);
+	free (names->prefix);
+	free (names->family);
+	free (names->suffix);
+	free (names->given_i);
+	free (names->prefix_i);
+	free (names->family_i);
+	free (names->suffix_i);
+}
+
+void test_parsename() {
+	for (int i = 0; i < parse_string_count; ++i) {
+		struct nametype names = parsename(parse_strings[i],"editor");
+		print_names(names);
+		free_names(&names);
+	}
+}
 
 int main (void)
 {
@@ -13,7 +206,10 @@ int main (void)
    printf ("split as we go:\n");
    for (i = 0; i < 4; i++)
    {
-      names[i] = bt_split_name (strdup (snames[i]), NULL, 0, 0);
+	   char * newsname = strdup(snames[i]);
+      names[i] = bt_split_name (snames[i], NULL, 0, 0);
+      assert (!strcmp(snames[i], newsname));
+      free (newsname);
       dump_name (names[i]);
    }
 
@@ -21,8 +217,10 @@ int main (void)
    for (i = 0; i < 4; i++)
    {
       dump_name (names[i]);
+      bt_free_name(names[i]);
    }
 
+   test_parsename();
    return 0;
 }
 

--- a/inc/MyBuilder.pm
+++ b/inc/MyBuilder.pm
@@ -306,6 +306,14 @@ sub ACTION_create_tests {
                                      objects => $objects);
     }
 
+    $exe_file = catfile("btparse","tests","namebug$EXEEXT");
+    $objects  = [ map{catfile("btparse","tests","$_.o")}(qw.namebug.) ];
+    if (!$self->up_to_date($objects, $exe_file)) {
+        $libbuilder->link_executable(exe_file => $exe_file,
+                                     extra_linker_flags => '-Lbtparse/src -lbtparse ',
+                                     objects => $objects);
+    }
+
     $exe_file = catfile("btparse","tests","purify_test$EXEEXT");
     $objects  = [ map{catfile("btparse","tests","$_.o")}(qw.purify_test.) ];
     if (!$self->up_to_date($objects, $exe_file)) {


### PR DESCRIPTION
Same bad string processing in biber triggerd some crashes in libbtparse.

I have tracked down all issues and tried to fix them. There were several uninitialized fields as well as wrong comma counts involved. While fixing the bug I reworked find_commas to combine all 3 passes into one. 