### PR TITLE
Haiku build support

### DIFF
--- a/Build.PL
+++ b/Build.PL
@@ -87,6 +87,15 @@ if ( $^O =~ /mswin32/i ) {
         unlink catfile( $libdir, $target );
     }
 }
+elsif ( $^O =~ /haiku/i ) {
+    $libdir =~ s/\bbin\b/lib/;
+    $hdrdir = $libdir;
+    $hdrdir =~ s!\blib\b!develop/headers!;
+    if ( $Config{archname} =~ /BePC/ ) {
+        $libdir .= "/x86";
+        $hdrdir .= "/x86";
+    }
+}
 else {
     if ( $Config{archname} =~ /^x86_64|^ppc64|^s390x|^aarch64|^riscv64/ ) {
         $libdir =~ s/\bbin\b/lib64/;

--- a/inc/MyBuilder.pm
+++ b/inc/MyBuilder.pm
@@ -385,6 +385,10 @@ sub ACTION_test {
         my $oldlibpath = $ENV{LIBPATH} || '/lib:/usr/lib';
         $ENV{LIBPATH} = catdir($self->blib, "usrlib").":$oldlibpath";
     }
+    elsif ($^O =~ /haiku/i) {
+        my $oldlibpath = $ENV{LIBRARY_PATH} || '/boot/system/lib:/boot/system/lib/x86';
+        $ENV{LIBRARY_PATH} = catdir($self->blib, "usrlib").":$oldlibpath";
+    }
     elsif ($^O =~ /cygwin/i) {
         # cygwin uses windows lib searching (PATH instead of LD_LIBRARY_PATH)
         my $oldpath = $ENV{PATH};


### PR DESCRIPTION
Set installation paths to Haiku conventions.
 * Libraries are in "lib", headers are in "develop/headers".
 * For x86, modern software is usually built for the secondary architecture, so the paths have the "/x86" subdirectory appended. The reason is that the primary compiler on x86 is the legacy gcc 2 compiler for ABI compatibility with BeOS. Recently, perl is only built with the modern toolchain, so we don't need primary architecture support for x86 any more.
 * Development libraries are symlinked in "develop/lib[/x86]", but this isn't handled here but only when a package is built (see https://github.com/haikuports/haikuports/pull/11589 for the haikuports recipe). This is normal. Other mainstream build systems like autotools and cmake also don't handle this specialty out of the box.

Set LIBRARY_PATH for tests.