### PR TITLE
Copy zzpre_ast prototype to match defn

### DIFF
--- a/btparse/pccts/ast.h
+++ b/btparse/pccts/ast.h
@@ -90,7 +90,7 @@ extern AST *zzastStack[];
 void zzlink(AST **, AST **, AST **);
 void zzsubchild(AST **, AST **, AST **);
 void zzsubroot(AST **, AST **, AST **);
-void zzpre_ast(AST *, void (*)(), void (*)(), void (*)());
+void zzpre_ast(AST *, void (*)(AST *), void (*)(AST *), void (*)(AST *));
 void zzfree_ast(AST *);
 AST *zztmake(AST *, ...);
 AST *zzdup_ast(AST *);


### PR DESCRIPTION
Fixes #38.

I don't really know what I'm doing but I can copy-paste like the best of 'em!

I'm still testing this on Fedora but it seems to at least build so far...